### PR TITLE
replace vec with map

### DIFF
--- a/omnipaxos/Cargo.toml
+++ b/omnipaxos/Cargo.toml
@@ -23,6 +23,7 @@ omnipaxos_macros = { version = "0.1.3", path = "../omnipaxos_macros", optional =
 lru = { version = "0.11.0", optional = true }
 num-traits = { version = "0.2.16", optional = true }
 linked_hash_set = { version = "0.1.4", optional = true }
+nohash-hasher = "0.2.0"
 
 [dev-dependencies]
 kompact = { git = "https://github.com/kompics/kompact", rev = "4fd1fdc", features = ["silent_logging"] }

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -20,8 +20,7 @@ where
         #[cfg(feature = "logging")]
         debug!(self.logger, "Newly elected leader: {:?}", n);
         if self.pid == n.pid {
-            self.leader_state =
-                LeaderState::with(n, self.leader_state.max_pid, self.leader_state.quorum);
+            self.leader_state = LeaderState::with(n, &self.peers, self.leader_state.quorum);
             // Flush any pending writes
             // Don't have to handle flushed entries here because we will sync with followers
             let _ = self.internal_storage.flush_batch().expect(WRITE_ERROR_MSG);

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -137,7 +137,7 @@ where
 
     /// Initiates the trim process.
     /// # Arguments
-    /// * `trim_idx` - Deletes all entries up to [`trim_idx`], if the [`trim_idx`] is `None` then the minimum index accepted by **ALL** servers will be used as the [`trim_idx`].
+    /// * `trim_idx` - Deletes all entries up to [`trim_idx`], if the [`trim_idx`] is `None` then `decided_idx`  will be used as the [`trim_idx`].
     pub(crate) fn trim(&mut self, trim_idx: Option<usize>) -> Result<(), CompactionErr> {
         match self.state {
             (Role::Leader, _) => {

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -55,8 +55,6 @@ where
         let peers = config.peers;
         let num_nodes = &peers.len() + 1;
         let quorum = Quorum::with(config.flexible_quorum, num_nodes);
-        let max_peer_pid = peers.iter().max().unwrap();
-        let max_pid = *std::cmp::max(max_peer_pid, &pid) as usize;
         let mut outgoing = Vec::with_capacity(config.buffer_size);
         let (state, leader) = match storage
             .get_promise()
@@ -88,12 +86,12 @@ where
                 pid,
             ),
             pid,
-            peers,
+            peers: peers.clone(),
             state,
             buffered_proposals: vec![],
             buffered_stopsign: None,
             outgoing,
-            leader_state: LeaderState::<T>::with(leader, max_pid, quorum),
+            leader_state: LeaderState::<T>::with(leader, &peers, quorum),
             latest_accepted_meta: None,
             current_seq_num: SequenceNumber::default(),
             cached_promise_message: None,

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -141,20 +141,20 @@ where
     pub(crate) fn trim(&mut self, trim_idx: Option<usize>) -> Result<(), CompactionErr> {
         match self.state {
             (Role::Leader, _) => {
-                let min_all_accepted_idx = self.leader_state.get_min_all_accepted_idx();
+                let decided_idx = self.get_decided_idx();
                 let trimmed_idx = match trim_idx {
-                    Some(idx) if idx <= *min_all_accepted_idx => idx,
+                    Some(idx) if idx <= decided_idx => idx,
                     None => {
                         #[cfg(feature = "logging")]
                         trace!(
                             self.logger,
                             "No trim index provided, using min_las_idx: {:?}",
-                            min_all_accepted_idx
+                            decided_idx
                         );
-                        *min_all_accepted_idx
+                        decided_idx
                     }
                     _ => {
-                        return Err(CompactionErr::NotAllDecided(*min_all_accepted_idx));
+                        return Err(CompactionErr::NotAllDecided(decided_idx));
                     }
                 };
                 let result = self.internal_storage.try_trim(trimmed_idx);

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -5,7 +5,7 @@ use super::{
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, fmt::Debug, marker::PhantomData};
+use std::{cmp::Ordering, collections::HashMap, fmt::Debug, marker::PhantomData};
 
 /// Struct used to help another server synchronize their log with the current state of our own log.
 #[derive(Clone, Debug)]
@@ -70,20 +70,21 @@ enum PromiseState {
     PromisedHigher,
 }
 
+type IntMap<V> = HashMap<NodeId, V>;
+
 #[derive(Debug, Clone)]
 pub(crate) struct LeaderState<T>
 where
     T: Entry,
 {
     pub n_leader: Ballot,
-    promises_meta: Vec<PromiseState>,
+    promises_meta: IntMap<PromiseState>,
     // the sequence number of accepts for each follower where AcceptSync has sequence number = 1
-    follower_seq_nums: Vec<SequenceNumber>,
-    pub accepted_indexes: Vec<usize>,
+    follower_seq_nums: IntMap<SequenceNumber>,
+    pub accepted_indexes: IntMap<usize>,
     max_promise_meta: PromiseMetaData,
     max_promise_sync: Option<LogSync<T>>,
-    latest_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
-    pub max_pid: usize,
+    latest_accept_meta: IntMap<Option<(Ballot, usize)>>, //  index in outgoing
     // The number of promises needed in the prepare phase to become synced and
     // the number of accepteds needed in the accept phase to decide an entry.
     pub quorum: Quorum,
@@ -93,41 +94,58 @@ impl<T> LeaderState<T>
 where
     T: Entry,
 {
-    pub fn with(n_leader: Ballot, max_pid: usize, quorum: Quorum) -> Self {
+    pub fn with(n_leader: Ballot, peers: &[NodeId], quorum: Quorum) -> Self {
+        let mut promises_meta = IntMap::new();
+        let mut follower_seq_nums = IntMap::new();
+        let mut accepted_indexes = IntMap::new();
+        let mut latest_accept_meta = IntMap::new();
+
+        // Initialize maps for all peers
+        for &peer in peers.iter() {
+            promises_meta.insert(peer, PromiseState::NotPromised);
+            follower_seq_nums.insert(peer, SequenceNumber::default());
+            accepted_indexes.insert(peer, 0);
+            latest_accept_meta.insert(peer, None);
+        }
+
         Self {
             n_leader,
-            promises_meta: vec![PromiseState::NotPromised; max_pid],
-            follower_seq_nums: vec![SequenceNumber::default(); max_pid],
-            accepted_indexes: vec![0; max_pid],
+            promises_meta,
+            follower_seq_nums,
+            accepted_indexes,
             max_promise_meta: PromiseMetaData::default(),
             max_promise_sync: None,
-            latest_accept_meta: vec![None; max_pid],
-            max_pid,
+            latest_accept_meta,
             quorum,
         }
     }
 
-    fn pid_to_idx(pid: NodeId) -> usize {
-        (pid - 1) as usize
-    }
-
-    // Resets `pid`'s accept sequence to indicate they are in the next session of accepts
     pub fn increment_seq_num_session(&mut self, pid: NodeId) {
-        let idx = Self::pid_to_idx(pid);
-        self.follower_seq_nums[idx].session += 1;
-        self.follower_seq_nums[idx].counter = 0;
+        if let Some(seq_num) = self.follower_seq_nums.get_mut(&pid) {
+            seq_num.session += 1;
+            seq_num.counter = 0;
+        }
     }
 
     pub fn next_seq_num(&mut self, pid: NodeId) -> SequenceNumber {
-        let idx = Self::pid_to_idx(pid);
-        self.follower_seq_nums[idx].counter += 1;
-        self.follower_seq_nums[idx]
+        if let Some(seq_num) = self.follower_seq_nums.get_mut(&pid) {
+            seq_num.counter += 1;
+            *seq_num
+        } else {
+            // Handle case where pid is not in the map
+            let mut new_seq = SequenceNumber::default();
+            new_seq.counter = 1;
+            self.follower_seq_nums.insert(pid, new_seq);
+            new_seq
+        }
     }
 
-    pub fn get_seq_num(&mut self, pid: NodeId) -> SequenceNumber {
-        self.follower_seq_nums[Self::pid_to_idx(pid)]
+    pub fn get_seq_num(&self, pid: NodeId) -> SequenceNumber {
+        self.follower_seq_nums
+            .get(&pid)
+            .copied()
+            .unwrap_or_default()
     }
-
     pub fn set_promise(&mut self, prom: Promise<T>, from: NodeId, check_max_prom: bool) -> bool {
         let promise_meta = PromiseMetaData {
             n_accepted: prom.n_accepted,
@@ -139,22 +157,24 @@ where
             self.max_promise_meta = promise_meta.clone();
             self.max_promise_sync = prom.log_sync;
         }
-        self.promises_meta[Self::pid_to_idx(from)] = PromiseState::Promised(promise_meta);
+        self.promises_meta
+            .insert(from, PromiseState::Promised(promise_meta));
+
         let num_promised = self
             .promises_meta
-            .iter()
+            .values()
             .filter(|p| matches!(p, PromiseState::Promised(_)))
             .count();
         self.quorum.is_prepare_quorum(num_promised)
     }
 
     pub fn reset_promise(&mut self, pid: NodeId) {
-        self.promises_meta[Self::pid_to_idx(pid)] = PromiseState::NotPromised;
+        self.promises_meta.insert(pid, PromiseState::NotPromised);
     }
 
     /// Node `pid` seen with ballot greater than my ballot
     pub fn lost_promise(&mut self, pid: NodeId) {
-        self.promises_meta[Self::pid_to_idx(pid)] = PromiseState::PromisedHigher;
+        self.promises_meta.insert(pid, PromiseState::PromisedHigher);
     }
 
     pub fn take_max_promise_sync(&mut self) -> Option<LogSync<T>> {
@@ -167,7 +187,7 @@ where
 
     pub fn get_max_decided_idx(&self) -> usize {
         self.promises_meta
-            .iter()
+            .values()
             .filter_map(|p| match p {
                 PromiseState::Promised(m) => Some(m.decided_idx),
                 _ => None,
@@ -177,24 +197,23 @@ where
     }
 
     pub fn get_promise_meta(&self, pid: NodeId) -> &PromiseMetaData {
-        match &self.promises_meta[Self::pid_to_idx(pid)] {
-            PromiseState::Promised(metadata) => metadata,
+        match self.promises_meta.get(&pid) {
+            Some(PromiseState::Promised(metadata)) => metadata,
             _ => panic!("No Metadata found for promised follower"),
         }
     }
 
     pub fn reset_latest_accept_meta(&mut self) {
-        self.latest_accept_meta = vec![None; self.max_pid];
+        for value in self.latest_accept_meta.values_mut() {
+            *value = None;
+        }
     }
 
     pub fn get_promised_followers(&self) -> Vec<NodeId> {
         self.promises_meta
             .iter()
-            .enumerate()
-            .filter_map(|(idx, x)| match x {
-                PromiseState::Promised(_) if idx != Self::pid_to_idx(self.n_leader.pid) => {
-                    Some((idx + 1) as NodeId)
-                }
+            .filter_map(|(pid, x)| match x {
+                PromiseState::Promised(_) if *pid != self.n_leader.pid => Some(*pid),
                 _ => None,
             })
             .collect()
@@ -204,48 +223,41 @@ where
     pub(crate) fn get_preparable_peers(&self, peers: &[NodeId]) -> Vec<NodeId> {
         peers
             .iter()
-            .filter_map(|pid| {
-                let idx = Self::pid_to_idx(*pid);
-                match self.promises_meta.get(idx).unwrap() {
-                    PromiseState::NotPromised => Some(*pid),
-                    _ => None,
-                }
+            .filter_map(|pid| match self.promises_meta.get(pid).unwrap() {
+                PromiseState::NotPromised => Some(*pid),
+                _ => None,
             })
             .collect()
     }
 
     pub fn set_latest_accept_meta(&mut self, pid: NodeId, idx: Option<usize>) {
         let meta = idx.map(|x| (self.n_leader, x));
-        self.latest_accept_meta[Self::pid_to_idx(pid)] = meta;
+        self.latest_accept_meta.insert(pid, meta);
     }
 
     pub fn set_accepted_idx(&mut self, pid: NodeId, idx: usize) {
-        self.accepted_indexes[Self::pid_to_idx(pid)] = idx;
+        self.accepted_indexes.insert(pid, idx);
     }
 
     pub fn get_latest_accept_meta(&self, pid: NodeId) -> Option<(Ballot, usize)> {
-        self.latest_accept_meta
-            .get(Self::pid_to_idx(pid))
-            .unwrap()
-            .as_ref()
-            .copied()
+        self.latest_accept_meta.get(&pid).and_then(|x| *x)
     }
 
     pub fn get_decided_idx(&self, pid: NodeId) -> Option<usize> {
-        match self.promises_meta.get(Self::pid_to_idx(pid)).unwrap() {
-            PromiseState::Promised(metadata) => Some(metadata.decided_idx),
+        match self.promises_meta.get(&pid) {
+            Some(PromiseState::Promised(metadata)) => Some(metadata.decided_idx),
             _ => None,
         }
     }
 
     pub fn get_accepted_idx(&self, pid: NodeId) -> usize {
-        *self.accepted_indexes.get(Self::pid_to_idx(pid)).unwrap()
+        self.accepted_indexes.get(&pid).copied().unwrap_or(0)
     }
 
     pub fn is_chosen(&self, idx: usize) -> bool {
         let num_accepted = self
             .accepted_indexes
-            .iter()
+            .values()
             .filter(|la| **la >= idx)
             .count();
         self.quorum.is_accept_quorum(num_accepted)
@@ -480,7 +492,7 @@ mod tests {
         let quorum = Quorum::Majority(2);
         let max_pid = 8;
         let leader_state =
-            LeaderState::<Value>::with(Ballot::with(1, 1, 1, max_pid), max_pid as usize, quorum);
+            LeaderState::<Value>::with(Ballot::with(1, 1, 1, max_pid), &nodes, quorum);
         let prep_peers = leader_state.get_preparable_peers(&nodes);
         assert_eq!(prep_peers, nodes);
 
@@ -488,7 +500,7 @@ mod tests {
         let quorum = Quorum::Majority(3);
         let max_pid = 100;
         let leader_state =
-            LeaderState::<Value>::with(Ballot::with(1, 1, 1, max_pid), max_pid as usize, quorum);
+            LeaderState::<Value>::with(Ballot::with(1, 1, 1, max_pid), &nodes, quorum);
         let prep_peers = leader_state.get_preparable_peers(&nodes);
         assert_eq!(prep_peers, nodes);
     }

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -183,13 +183,14 @@ where
         }
     }
 
-    pub fn get_min_all_accepted_idx(&self) -> &usize {
-        self.accepted_indexes
-            .iter()
-            .min()
-            .expect("Should be all initialised to 0!")
-    }
-
+    //    pub fn get_min_all_accepted_idx(&self) -> usize {
+    //        self.accepted_indexes
+    //            .values()
+    //            .min()
+    //            .copied()
+    //            .expect("No accepted indexes found")
+    //    }
+    //
     pub fn reset_latest_accept_meta(&mut self) {
         self.latest_accept_meta = vec![None; self.max_pid];
     }

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -183,14 +183,6 @@ where
         }
     }
 
-    //    pub fn get_min_all_accepted_idx(&self) -> usize {
-    //        self.accepted_indexes
-    //            .values()
-    //            .min()
-    //            .copied()
-    //            .expect("No accepted indexes found")
-    //    }
-    //
     pub fn reset_latest_accept_meta(&mut self) {
         self.latest_accept_meta = vec![None; self.max_pid];
     }

--- a/omnipaxos/src/utils/ui.rs
+++ b/omnipaxos/src/utils/ui.rs
@@ -1,17 +1,15 @@
-use std::collections::HashMap;
-
 use crate::{
     ballot_leader_election::Ballot,
     messages::ballot_leader_election::HeartbeatReply,
     storage::Entry,
-    util::{LeaderState, NodeId},
+    util::{LeaderState, NodeId, NodeMap},
 };
 
 /// The states of all the nodes in the cluster.
 #[derive(Debug, Clone, Default)]
 pub struct ClusterState {
     /// The accepted indexes of all the nodes in the cluster. The index of the vector is the node id.
-    pub accepted_indexes: HashMap<NodeId, usize>,
+    pub accepted_indexes: NodeMap<usize>,
     /// All the received heartbeats from the previous heartbeat round, including the current node.
     /// Represents nodes that are currently alive from the view of the current node.
     pub heartbeats: Vec<HeartbeatReply>,

--- a/omnipaxos/src/utils/ui.rs
+++ b/omnipaxos/src/utils/ui.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::{
     ballot_leader_election::Ballot,
     messages::ballot_leader_election::HeartbeatReply,
@@ -9,7 +11,7 @@ use crate::{
 #[derive(Debug, Clone, Default)]
 pub struct ClusterState {
     /// The accepted indexes of all the nodes in the cluster. The index of the vector is the node id.
-    pub accepted_indexes: Vec<usize>,
+    pub accepted_indexes: HashMap<NodeId, usize>,
     /// All the received heartbeats from the previous heartbeat round, including the current node.
     /// Represents nodes that are currently alive from the view of the current node.
     pub heartbeats: Vec<HeartbeatReply>,

--- a/omnipaxos_ui/src/lib.rs
+++ b/omnipaxos_ui/src/lib.rs
@@ -122,7 +122,7 @@ impl OmniPaxosUI {
                     } else {
                         accepted_idx as f64 / leader_acc_idx as f64
                     };
-                    //        self.app.followers_accepted_idx[idx] = accepted_idx;
+                    self.app.followers_accepted_idx[idx as usize] = accepted_idx;
                 }
             } else {
                 // Current node is a follower

--- a/omnipaxos_ui/src/lib.rs
+++ b/omnipaxos_ui/src/lib.rs
@@ -109,16 +109,20 @@ impl OmniPaxosUI {
                 // Current node is the leader
                 self.app.current_role = Role::Leader;
                 // Update the progress of all the followers
-                let leader_acc_idx = op_states.cluster_state.accepted_indexes[leader_id as usize];
-                for (idx, &accepted_idx) in
-                    op_states.cluster_state.accepted_indexes.iter().enumerate()
-                {
-                    self.app.followers_progress[idx] = if leader_acc_idx == 0 {
+                let leader_acc_idx = op_states
+                    .cluster_state
+                    .accepted_indexes
+                    .get(&leader_id)
+                    .copied()
+                    .unwrap_or(0);
+
+                for (&idx, &accepted_idx) in op_states.cluster_state.accepted_indexes.iter() {
+                    self.app.followers_progress[idx as usize] = if leader_acc_idx == 0 {
                         0.0 // To avoid division by zero
                     } else {
                         accepted_idx as f64 / leader_acc_idx as f64
                     };
-                    self.app.followers_accepted_idx[idx] = accepted_idx;
+                    //        self.app.followers_accepted_idx[idx] = accepted_idx;
                 }
             } else {
                 // Current node is a follower


### PR DESCRIPTION
Omnipaxos using array as Map i.e  `Vec<MAX_NODEID>` to store other node's info.
This could be problematic with large ReplicaIds used in spacetimedb.

based on - https://github.com/clockworklabs/omnipaxos/pull/4

