### PR TITLE
trim on decided

### DIFF
--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -137,7 +137,7 @@ where
 
     /// Initiates the trim process.
     /// # Arguments
-    /// * `trim_idx` - Deletes all entries up to [`trim_idx`], if the [`trim_idx`] is `None` then the minimum index accepted by **ALL** servers will be used as the [`trim_idx`].
+    /// * `trim_idx` - Deletes all entries up to [`trim_idx`], if the [`trim_idx`] is `None` then `decided_idx`  will be used as the [`trim_idx`].
     pub(crate) fn trim(&mut self, trim_idx: Option<usize>) -> Result<(), CompactionErr> {
         match self.state {
             (Role::Leader, _) => {

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -141,20 +141,20 @@ where
     pub(crate) fn trim(&mut self, trim_idx: Option<usize>) -> Result<(), CompactionErr> {
         match self.state {
             (Role::Leader, _) => {
-                let min_all_accepted_idx = self.leader_state.get_min_all_accepted_idx();
+                let decided_idx = self.get_decided_idx();
                 let trimmed_idx = match trim_idx {
-                    Some(idx) if idx <= *min_all_accepted_idx => idx,
+                    Some(idx) if idx <= decided_idx => idx,
                     None => {
                         #[cfg(feature = "logging")]
                         trace!(
                             self.logger,
                             "No trim index provided, using min_las_idx: {:?}",
-                            min_all_accepted_idx
+                            decided_idx
                         );
-                        *min_all_accepted_idx
+                        decided_idx
                     }
                     _ => {
-                        return Err(CompactionErr::NotAllDecided(*min_all_accepted_idx));
+                        return Err(CompactionErr::NotAllDecided(decided_idx));
                     }
                 };
                 let result = self.internal_storage.try_trim(trimmed_idx);

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -183,13 +183,14 @@ where
         }
     }
 
-    pub fn get_min_all_accepted_idx(&self) -> &usize {
-        self.accepted_indexes
-            .iter()
-            .min()
-            .expect("Should be all initialised to 0!")
-    }
-
+    //    pub fn get_min_all_accepted_idx(&self) -> usize {
+    //        self.accepted_indexes
+    //            .values()
+    //            .min()
+    //            .copied()
+    //            .expect("No accepted indexes found")
+    //    }
+    //
     pub fn reset_latest_accept_meta(&mut self) {
         self.latest_accept_meta = vec![None; self.max_pid];
     }

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -183,14 +183,6 @@ where
         }
     }
 
-    //    pub fn get_min_all_accepted_idx(&self) -> usize {
-    //        self.accepted_indexes
-    //            .values()
-    //            .min()
-    //            .copied()
-    //            .expect("No accepted indexes found")
-    //    }
-    //
     pub fn reset_latest_accept_meta(&mut self) {
         self.latest_accept_meta = vec![None; self.max_pid];
     }


### PR DESCRIPTION
Snapshoting can be slow, made trimming to be done on `decided_idx` to be able to use it.