### PR TITLE
Make storage error `Send + Sync + 'static`

### DIFF
--- a/omnipaxos/src/storage/mod.rs
+++ b/omnipaxos/src/storage/mod.rs
@@ -95,7 +95,7 @@ where
 }
 
 /// The Result type returned by the storage API.
-pub type StorageResult<T> = Result<T, Box<dyn Error>>;
+pub type StorageResult<T> = Result<T, Box<dyn Error + Send + Sync + 'static>>;
 
 /// The write operations of the storge implementation.
 #[derive(Debug)]


### PR DESCRIPTION
It is very common in applications that `Err` results are sent across thread boundaries, which the missing bounds complicate unnecessarily. Also makes the error compatible with `anyhow`.

---

Resubmitting here, as upstream is unresponsive.